### PR TITLE
Change caret color on light theme

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -119,7 +119,8 @@ body{
     color:#eee;
     width:20rem;
     accent-color:var(--lightt);
-    box-shadow:none
+    box-shadow:none;
+    caret-color: var(--darkt);
 }
 @media (max-width:768px){
     .form-control,.form-control:focus,.from-control:active{


### PR DESCRIPTION
Change caret color from white to --darkt because on active state  white color caret  is not visible enough  on light theme.



# Problem
-On hover Box-Item grows in size now
# Solution
-transform property added to box-item on hover

## Changes proposed in this Pull Request :
-  `1.`transform property added to box-item on hover
-  `2.`on hover color of the contributors name changes to navy
-  `..`

## Other changes
-
